### PR TITLE
Property 'children' does not exist

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,5 +22,5 @@ export function useReactPWAInstall(): {
  *
  *  See: https://www.npmjs.com/package/react-pwa-install for more info.
  */
-export const ReactPWAInstallProvider: React.FC<{ enableLogging?: boolean }>;
+export const ReactPWAInstallProvider: React.FC<{ enableLogging?: boolean, children: JSX.Element | Element; }>;
 export default ReactPWAInstallProvider;


### PR DESCRIPTION
Fixing Typescript error: Type '{ children: Element; enableLogging: true; }' is not assignable to type 'IntrinsicAttributes & { enableLogging?: boolean | undefined; }'.
  Property 'children' does not exist on type 'IntrinsicAttributes & { enableLogging?: boolean | undefined; }'